### PR TITLE
Fix for log4net properties

### DIFF
--- a/log4net.aws/SimpleDBAppender.cs
+++ b/log4net.aws/SimpleDBAppender.cs
@@ -24,21 +24,27 @@ namespace log4net.Appender
             set { _dbName = value; }
         }
 
-        public SimpleDBAppender()
+        public override void ActivateOptions()
         {
+            base.ActivateOptions();
+
             var client = new AmazonSimpleDBClient();
-            ListDomainsRequest request=new ListDomainsRequest();
+            ListDomainsRequest request = new ListDomainsRequest();
             var response = client.ListDomains(request);
             bool found = response.ListDomainsResult.DomainName.Any(d => d == DBName);
             if (!found)
             {
                 CreateDomainRequest createDomainRequest =
                     new CreateDomainRequest
-                        {
-                            DomainName = DBName
-                        };
+                    {
+                        DomainName = DBName
+                    };
                 client.CreateDomain(createDomainRequest);
             }
+        }
+
+        public SimpleDBAppender()
+        {
         }
 
         /// <summary>


### PR DESCRIPTION
It doesn't look like you can access log4net properties in the constructor of an appender. Moving them to after the ActivateOptions call seems to have worked in my testing.
